### PR TITLE
頭条 (Toutiao) プラットフォームの追加

### DIFF
--- a/doc/trendradar_platform_integrations.md
+++ b/doc/trendradar_platform_integrations.md
@@ -22,6 +22,14 @@ TrendRadar MCP サーバー経由で複数のプラットフォームのホッ�
 - **ベース実装参照**: `zhihu_explorer.py` を継承・参考にする
 
 ---
+ 
+> [!IMPORTANT]
+> **新プラットフォーム統合時の重要事項**
+> 新しいプラットフォームを追加する際は、`nook/services/runner/runner_impl.py` への登録を絶対に忘れないでください。他プラットフォーム（Zhihu, Juejin等）の登録箇所を検索し、以下の対応を必ず実施してください：
+> 1. `ToutiaoExplorer` 等のクラスをインポート
+> 2. `self.service_classes` への追加
+> 3. `_run_sync_service` 内のバリデーション・実行対象への追加
+> 4. `main` 関数の `argparse` choices への追加
 
 ## 📋 プラットフォーム一覧
 
@@ -501,7 +509,7 @@ const sources = [
 | IT之家（ITHome） | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 36氪（36Kr） | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 微博（Weibo） | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| 今日头条（Toutiao） | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| 今日头条（Toutiao） | ✅ | ✅ | ✅ | ✅ | ⬜ |
 | 少数派（SSPai） | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | Product Hunt | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ const sources = [
   'trendradar-ithome',
   'trendradar-36kr',
   'trendradar-weibo',
+  'trendradar-toutiao',
 ];
 
 function App() {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -60,6 +60,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         'trendradar-ithome',
         'trendradar-36kr',
         'trendradar-weibo',
+        'trendradar-toutiao',
       ],
       defaultExpanded: true,
     },

--- a/frontend/src/config/sourceDisplayInfo.ts
+++ b/frontend/src/config/sourceDisplayInfo.ts
@@ -136,6 +136,14 @@ export const sourceDisplayInfo: Record<string, SourceDisplayInfo> = {
     gradientTo: 'to-yellow-50',
     borderColor: 'border-red-300',
   },
+  'trendradar-toutiao': {
+    title: '今日头条 (Toutiao)',
+    subtitle: '中国最大のニュースアグリゲーター',
+    dateFormat: 'yyyy年MM月dd日',
+    gradientFrom: 'from-red-50',
+    gradientTo: 'to-red-100',
+    borderColor: 'border-red-200',
+  },
 };
 
 // デフォルト設定

--- a/frontend/src/config/sourceDisplayInfo.ts
+++ b/frontend/src/config/sourceDisplayInfo.ts
@@ -140,9 +140,9 @@ export const sourceDisplayInfo: Record<string, SourceDisplayInfo> = {
     title: '今日头条 (Toutiao)',
     subtitle: '中国最大のニュースアグリゲーター',
     dateFormat: 'yyyy年MM月dd日',
-    gradientFrom: 'from-red-50',
-    gradientTo: 'to-red-100',
-    borderColor: 'border-red-200',
+    gradientFrom: 'from-amber-50',
+    gradientTo: 'to-amber-100',
+    borderColor: 'border-amber-200',
   },
 };
 

--- a/nook/api/routers/content.py
+++ b/nook/api/routers/content.py
@@ -58,6 +58,7 @@ SOURCE_MAPPING = {
     "trendradar-ithome": "trendradar-ithome",
     "trendradar-36kr": "trendradar-36kr",
     "trendradar-weibo": "trendradar-weibo",
+    "trendradar-toutiao": "trendradar-toutiao",
 }
 
 
@@ -209,6 +210,7 @@ async def get_content(
             "trendradar-ithome",
             "trendradar-36kr",
             "trendradar-weibo",
+            "trendradar-toutiao",
         ):
             articles_data = storage.load_json(service_name, target_date)
             if articles_data:
@@ -273,6 +275,7 @@ async def get_content(
                 "trendradar-ithome",
                 "trendradar-36kr",
                 "trendradar-weibo",
+                "trendradar-toutiao",
             ):
                 # TrendRadar系はJSONから個別記事として追加
                 articles_data = storage.load_json(service_name, target_date)
@@ -357,5 +360,6 @@ def _get_source_display_name(source: str) -> str:
         "trendradar-ithome": "IT之家 (ITHome)",
         "trendradar-36kr": "36氪 (36Kr)",
         "trendradar-weibo": "微博 (Weibo)",
+        "trendradar-toutiao": "今日头条 (Toutiao)",
     }
     return source_names.get(source, source)

--- a/nook/services/explorers/trendradar/__init__.py
+++ b/nook/services/explorers/trendradar/__init__.py
@@ -4,6 +4,7 @@ from nook.services.explorers.trendradar.base import BaseTrendRadarExplorer
 from nook.services.explorers.trendradar.ithome_explorer import IthomeExplorer
 from nook.services.explorers.trendradar.juejin_explorer import JuejinExplorer
 from nook.services.explorers.trendradar.kr36_explorer import Kr36Explorer
+from nook.services.explorers.trendradar.toutiao_explorer import ToutiaoExplorer
 from nook.services.explorers.trendradar.trendradar_client import (
     TrendRadarClient,
     TrendRadarError,
@@ -20,4 +21,5 @@ __all__ = [
     "JuejinExplorer",
     "Kr36Explorer",
     "WeiboExplorer",
+    "ToutiaoExplorer",
 ]

--- a/nook/services/explorers/trendradar/toutiao_explorer.py
+++ b/nook/services/explorers/trendradar/toutiao_explorer.py
@@ -12,8 +12,8 @@ from nook.services.explorers.trendradar.base import BaseTrendRadarExplorer
 class ToutiaoExplorer(BaseTrendRadarExplorer):
     """今日头条のホットニュースをTrendRadar経由で取得するExplorer.
 
-    TrendRadar MCPサーバーと通信し、今日头条（Toutiao）のホットニュースを
-    取得・要約・保存します。
+    TrendRadar MCPサーバーと通信し、
+    今日头条（Toutiao）のホットニュースを取得・要約・保存します。
 
     Parameters
     ----------

--- a/nook/services/explorers/trendradar/toutiao_explorer.py
+++ b/nook/services/explorers/trendradar/toutiao_explorer.py
@@ -1,0 +1,85 @@
+"""ToutiaoExplorer - TrendRadar経由で今日头条のホットニュースを取得.
+
+このモジュールは、TrendRadar MCPサーバーを経由して
+今日头条（Toutiao）のホットニュースを取得するToutiaoExplorerクラスを提供します。
+"""
+
+from nook.core.config import BaseConfig
+from nook.services.base.base_feed_service import Article
+from nook.services.explorers.trendradar.base import BaseTrendRadarExplorer
+
+
+class ToutiaoExplorer(BaseTrendRadarExplorer):
+    """今日头条のホットニュースをTrendRadar経由で取得するExplorer.
+
+    TrendRadar MCPサーバーと通信し、今日头条（Toutiao）のホットニュースを
+    取得・要約・保存します。
+
+    Parameters
+    ----------
+    storage_dir : str, default="var/data"
+        データ保存ディレクトリのルートパス。
+
+    Examples
+    --------
+    >>> explorer = ToutiaoExplorer()
+    >>> explorer.run(days=1, limit=20)
+    """
+
+    # プラットフォーム固有の設定
+    PLATFORM_NAME = "toutiao"
+    FEED_NAME = "toutiao"
+    MARKDOWN_HEADER = "今日头条ホットニュース"
+
+    def __init__(self, storage_dir: str = "var/data", config: BaseConfig | None = None):
+        """ToutiaoExplorerを初期化.
+
+        Parameters
+        ----------
+        storage_dir : str, default="var/data"
+            データ保存ディレクトリのルートパス。
+        config : BaseConfig | None, default=None
+            設定オブジェクト。
+        """
+        super().__init__(
+            service_name="trendradar-toutiao",
+            storage_dir=storage_dir,
+            config=config,
+        )
+
+    def _get_summary_prompt(self, article: Article) -> str:
+        """GPT要約用のプロンプトを生成."""
+        safe_title = self._sanitize_prompt_input(article.title, max_length=200)
+        safe_url = self._sanitize_prompt_input(article.url, max_length=500)
+        safe_text = self._sanitize_prompt_input(article.text or "", max_length=500)
+
+        return f"""以下の今日头条（Toutiao）ホットニュースを日本語で詳細に要約してください。
+
+タイトル: {safe_title}
+URL: {safe_url}
+説明: {safe_text}
+
+以下のフォーマットで出力してください：
+
+1. ニュースの概要 (1-2文)
+[主要なニュース内容を簡潔に説明]
+
+2. 重要なポイント (箇条書き3-5点)
+- [ポイント1: 事実関係]
+- [ポイント2: 関係者・組織]
+- [ポイント3: 影響範囲]
+
+3. 社会的影響
+[このニュースがもたらす影響や意味]
+
+4. 国際的視点
+[日本や国際社会との関連性]"""
+
+    def _get_system_instruction(self) -> str:
+        """GPT要約用のシステム指示を取得."""
+        return (
+            "あなたは中国のニュースアグリゲーター「今日头条（Toutiao）」のトレンドを"
+            "日本語で解説する専門のアシスタントです。日本のユーザーに向けて、"
+            "ニュースの要点、社会的影響、異なる視点からの分析が"
+            "伝わるような具体的で情報量の多い要約を作成してください。"
+        )

--- a/nook/services/explorers/trendradar/toutiao_explorer.py
+++ b/nook/services/explorers/trendradar/toutiao_explorer.py
@@ -19,6 +19,8 @@ class ToutiaoExplorer(BaseTrendRadarExplorer):
     ----------
     storage_dir : str, default="var/data"
         データ保存ディレクトリのルートパス。
+    config : BaseConfig | None, default=None
+        設定オブジェクト。
 
     Examples
     --------

--- a/nook/services/explorers/trendradar/trendradar_client.py
+++ b/nook/services/explorers/trendradar/trendradar_client.py
@@ -45,7 +45,7 @@ class TrendRadarClient:
 
     DEFAULT_URL = "http://localhost:3333/mcp"
     DEFAULT_TIMEOUT = 30
-    SUPPORTED_PLATFORMS = ["zhihu", "weibo", "juejin", "ithome", "36kr"]
+    SUPPORTED_PLATFORMS = ["zhihu", "weibo", "juejin", "ithome", "36kr", "toutiao"]
 
     def __init__(self, base_url: str | None = None):
         """Initialize TrendRadarClient.

--- a/nook/services/runner/runner_impl.py
+++ b/nook/services/runner/runner_impl.py
@@ -80,6 +80,10 @@ class ServiceRunner:
             "arxiv": ArxivSummarizer,
             "4chan": FourChanExplorer,
             "5chan": FiveChanExplorer,
+        }
+
+        # TrendRadarサービスを動的に登録
+        trendradar_mapping = {
             "trendradar-zhihu": ZhihuExplorer,
             "trendradar-juejin": JuejinExplorer,
             "trendradar-ithome": IthomeExplorer,
@@ -87,6 +91,9 @@ class ServiceRunner:
             "trendradar-weibo": WeiboExplorer,
             "trendradar-toutiao": ToutiaoExplorer,
         }
+        for service_name in TRENDRADAR_SERVICES:
+            if service_name in trendradar_mapping:
+                self.service_classes[service_name] = trendradar_mapping[service_name]
 
         # サービスインスタンスを保持（必要時にのみ作成）
         self.sync_services = {}

--- a/nook/services/runner/runner_impl.py
+++ b/nook/services/runner/runner_impl.py
@@ -48,6 +48,7 @@ class ServiceRunner:
         from nook.services.explorers.trendradar.ithome_explorer import IthomeExplorer
         from nook.services.explorers.trendradar.juejin_explorer import JuejinExplorer
         from nook.services.explorers.trendradar.kr36_explorer import Kr36Explorer
+        from nook.services.explorers.trendradar.toutiao_explorer import ToutiaoExplorer
         from nook.services.explorers.trendradar.weibo_explorer import WeiboExplorer
         from nook.services.explorers.trendradar.zhihu_explorer import ZhihuExplorer
         from nook.services.explorers.zenn.zenn_explorer import ZennExplorer
@@ -73,6 +74,7 @@ class ServiceRunner:
             "trendradar-ithome": IthomeExplorer,
             "trendradar-36kr": Kr36Explorer,
             "trendradar-weibo": WeiboExplorer,
+            "trendradar-toutiao": ToutiaoExplorer,
         }
 
         # サービスインスタンスを保持（必要時にのみ作成）
@@ -101,6 +103,7 @@ class ServiceRunner:
             "trendradar-ithome",
             "trendradar-36kr",
             "trendradar-weibo",
+            "trendradar-toutiao",
         ):
             if days != 1:
                 raise ValueError(
@@ -159,6 +162,7 @@ class ServiceRunner:
                     "trendradar-ithome",
                     "trendradar-36kr",
                     "trendradar-weibo",
+                    "trendradar-toutiao",
                 ):
                     result = await service.collect(days=days, target_dates=sorted_dates)
                 else:
@@ -335,6 +339,7 @@ async def main():
             "trendradar-ithome",
             "trendradar-36kr",
             "trendradar-weibo",
+            "trendradar-toutiao",
         ],
         default="all",
         help="実行するサービスを指定します",

--- a/nook/services/runner/runner_impl.py
+++ b/nook/services/runner/runner_impl.py
@@ -106,8 +106,6 @@ class ServiceRunner:
         effective_dates = target_dates or target_dates_set(days)
         sorted_dates = sorted(effective_dates)
 
-        # trendradar-zhihu は単一日のみ対応のため、days/target_dates の整合性を厳密に検証する
-        # Note: ZhihuExplorer.collect 内でも検証されるが、runner 側で早期に失敗させる
         # trendradar系サービスは単一日のみ対応のため、days/target_dates の整合性を厳密に検証する
         # Note: Explorer.collect 内でも検証されるが、runner 側で早期に失敗させる
         if service_name in TRENDRADAR_SERVICES:

--- a/nook/services/runner/runner_impl.py
+++ b/nook/services/runner/runner_impl.py
@@ -31,6 +31,17 @@ load_dotenv(".env.production")
 logger = setup_logger("service_runner")
 
 
+# TrendRadar系のサービス一覧（単一日実行のみ対応）
+TRENDRADAR_SERVICES = {
+    "trendradar-zhihu",
+    "trendradar-juejin",
+    "trendradar-ithome",
+    "trendradar-36kr",
+    "trendradar-weibo",
+    "trendradar-toutiao",
+}
+
+
 class ServiceRunner:
     """サービス実行マネージャー"""
 
@@ -97,14 +108,9 @@ class ServiceRunner:
 
         # trendradar-zhihu は単一日のみ対応のため、days/target_dates の整合性を厳密に検証する
         # Note: ZhihuExplorer.collect 内でも検証されるが、runner 側で早期に失敗させる
-        if service_name in (
-            "trendradar-zhihu",
-            "trendradar-juejin",
-            "trendradar-ithome",
-            "trendradar-36kr",
-            "trendradar-weibo",
-            "trendradar-toutiao",
-        ):
+        # trendradar系サービスは単一日のみ対応のため、days/target_dates の整合性を厳密に検証する
+        # Note: Explorer.collect 内でも検証されるが、runner 側で早期に失敗させる
+        if service_name in TRENDRADAR_SERVICES:
             if days != 1:
                 raise ValueError(
                     f"{service_name} は単一日のみ対応しています。単一の日付を指定してください。"
@@ -155,15 +161,8 @@ class ServiceRunner:
                 saved_files = result if result else []
             else:
                 # その他のサービスはデフォルト値を使用
-                # trendradar-zhihu, trendradar-juejin は days の検証を service 側でも行う
-                if service_name in (
-                    "trendradar-zhihu",
-                    "trendradar-juejin",
-                    "trendradar-ithome",
-                    "trendradar-36kr",
-                    "trendradar-weibo",
-                    "trendradar-toutiao",
-                ):
+                # trendradar系サービス は days の検証を service 側でも行う
+                if service_name in TRENDRADAR_SERVICES:
                     result = await service.collect(days=days, target_dates=sorted_dates)
                 else:
                     result = await service.collect(target_dates=sorted_dates)
@@ -334,13 +333,8 @@ async def main():
             "arxiv",
             "4chan",
             "5chan",
-            "trendradar-zhihu",
-            "trendradar-juejin",
-            "trendradar-ithome",
-            "trendradar-36kr",
-            "trendradar-weibo",
-            "trendradar-toutiao",
-        ],
+        ]
+        + sorted(list(TRENDRADAR_SERVICES)),
         default="all",
         help="実行するサービスを指定します",
     )

--- a/tests/services/explorers/trendradar/test_toutiao_explorer.py
+++ b/tests/services/explorers/trendradar/test_toutiao_explorer.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from nook.services.base.base_feed_service import Article
+from nook.services.explorers.trendradar.base import create_empty_soup
 from nook.services.explorers.trendradar.toutiao_explorer import ToutiaoExplorer
 from nook.services.explorers.trendradar.trendradar_client import TrendRadarClient
 
@@ -25,8 +26,7 @@ def explorer(mock_trendradar_client):
     return ToutiaoExplorer(storage_dir="test_data")
 
 
-@pytest.mark.asyncio
-async def test_initialization(explorer):
+def test_initialization(explorer):
     """初期化のテスト."""
     assert explorer.service_name == "trendradar-toutiao"
     assert explorer.PLATFORM_NAME == "toutiao"
@@ -34,15 +34,14 @@ async def test_initialization(explorer):
     assert explorer.MARKDOWN_HEADER == "今日头条ホットニュース"
 
 
-@pytest.mark.asyncio
-async def test_get_summary_prompt(explorer):
+def test_get_summary_prompt(explorer):
     """プロンプト生成のテスト."""
     article = Article(
         feed_name="toutiao",
         title="Test Title",
         url="http://example.com",
         text="Test Description",
-        soup=None,
+        soup=create_empty_soup(),
         published_at=datetime.now(timezone.utc),
     )
 
@@ -56,8 +55,7 @@ async def test_get_summary_prompt(explorer):
     assert "4. 国際的視点" in prompt
 
 
-@pytest.mark.asyncio
-async def test_get_system_instruction(explorer):
+def test_get_system_instruction(explorer):
     """システム指示取得のテスト."""
     instruction = explorer._get_system_instruction()
 
@@ -104,8 +102,7 @@ async def test_collect_success(explorer, mock_trendradar_client):
             mock_store.assert_called_once()
 
 
-@pytest.mark.asyncio
-async def test_transform_to_article_valid(explorer):
+def test_transform_to_article_valid(explorer):
     """_transform_to_article: 正常な変換のテスト."""
     item = {
         "title": "Valid Title",
@@ -126,8 +123,7 @@ async def test_transform_to_article_valid(explorer):
     assert article.popularity_score == 150
 
 
-@pytest.mark.asyncio
-async def test_transform_to_article_null_fields(explorer):
+def test_transform_to_article_null_fields(explorer):
     """_transform_to_article: 必須フィールド欠落やnullのハンドリング."""
     # desc is None
     item = {
@@ -144,8 +140,7 @@ async def test_transform_to_article_null_fields(explorer):
     assert article.popularity_score == 0
 
 
-@pytest.mark.asyncio
-async def test_transform_to_article_time_parsing(explorer):
+def test_transform_to_article_time_parsing(explorer):
     """_transform_to_article: timeフィールドのパーステスト."""
 
     # specific format YYYY-MM-DD HH:MM

--- a/tests/services/explorers/trendradar/test_toutiao_explorer.py
+++ b/tests/services/explorers/trendradar/test_toutiao_explorer.py
@@ -26,7 +26,8 @@ def explorer(mock_trendradar_client):
     return ToutiaoExplorer(storage_dir="test_data")
 
 
-def test_initialization(explorer):
+@pytest.mark.asyncio
+async def test_initialization(explorer):
     """初期化のテスト."""
     assert explorer.service_name == "trendradar-toutiao"
     assert explorer.PLATFORM_NAME == "toutiao"
@@ -34,7 +35,8 @@ def test_initialization(explorer):
     assert explorer.MARKDOWN_HEADER == "今日头条ホットニュース"
 
 
-def test_get_summary_prompt(explorer):
+@pytest.mark.asyncio
+async def test_get_summary_prompt(explorer):
     """プロンプト生成のテスト."""
     article = Article(
         feed_name="toutiao",
@@ -55,7 +57,8 @@ def test_get_summary_prompt(explorer):
     assert "4. 国際的視点" in prompt
 
 
-def test_get_system_instruction(explorer):
+@pytest.mark.asyncio
+async def test_get_system_instruction(explorer):
     """システム指示取得のテスト."""
     instruction = explorer._get_system_instruction()
 
@@ -102,7 +105,8 @@ async def test_collect_success(explorer, mock_trendradar_client):
             mock_store.assert_called_once()
 
 
-def test_transform_to_article_valid(explorer):
+@pytest.mark.asyncio
+async def test_transform_to_article_valid(explorer):
     """_transform_to_article: 正常な変換のテスト."""
     item = {
         "title": "Valid Title",
@@ -123,7 +127,8 @@ def test_transform_to_article_valid(explorer):
     assert article.popularity_score == 150
 
 
-def test_transform_to_article_null_fields(explorer):
+@pytest.mark.asyncio
+async def test_transform_to_article_null_fields(explorer):
     """_transform_to_article: 必須フィールド欠落やnullのハンドリング."""
     # desc is None
     item = {
@@ -140,7 +145,8 @@ def test_transform_to_article_null_fields(explorer):
     assert article.popularity_score == 0
 
 
-def test_transform_to_article_time_parsing(explorer):
+@pytest.mark.asyncio
+async def test_transform_to_article_time_parsing(explorer):
     """_transform_to_article: timeフィールドのパーステスト."""
 
     # specific format YYYY-MM-DD HH:MM

--- a/tests/services/explorers/trendradar/test_toutiao_explorer.py
+++ b/tests/services/explorers/trendradar/test_toutiao_explorer.py
@@ -7,6 +7,7 @@ import pytest
 
 from nook.services.base.base_feed_service import Article
 from nook.services.explorers.trendradar.toutiao_explorer import ToutiaoExplorer
+from nook.services.explorers.trendradar.trendradar_client import TrendRadarClient
 
 
 @pytest.fixture
@@ -64,6 +65,10 @@ async def test_get_system_instruction(explorer):
     assert "Toutiao" in instruction
     assert "日本のユーザーに向けて" in instruction
     assert "社会的影響" in instruction
+
+
+def test_toutiao_is_supported_platform_in_client():
+    assert "toutiao" in TrendRadarClient.SUPPORTED_PLATFORMS
 
 
 @pytest.mark.asyncio

--- a/tests/services/explorers/trendradar/test_toutiao_explorer.py
+++ b/tests/services/explorers/trendradar/test_toutiao_explorer.py
@@ -1,0 +1,208 @@
+"""ToutiaoExplorerのテストモジュール."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nook.services.base.base_feed_service import Article
+from nook.services.explorers.trendradar.toutiao_explorer import ToutiaoExplorer
+
+
+@pytest.fixture
+def mock_trendradar_client():
+    with patch(
+        "nook.services.explorers.trendradar.base.TrendRadarClient"
+    ) as MockClient:
+        client_instance = AsyncMock()
+        MockClient.return_value = client_instance
+        yield client_instance
+
+
+@pytest.fixture
+def explorer(mock_trendradar_client):
+    return ToutiaoExplorer(storage_dir="test_data")
+
+
+@pytest.mark.asyncio
+async def test_initialization(explorer):
+    """初期化のテスト."""
+    assert explorer.service_name == "trendradar-toutiao"
+    assert explorer.PLATFORM_NAME == "toutiao"
+    assert explorer.FEED_NAME == "toutiao"
+    assert explorer.MARKDOWN_HEADER == "今日头条ホットニュース"
+
+
+@pytest.mark.asyncio
+async def test_get_summary_prompt(explorer):
+    """プロンプト生成のテスト."""
+    article = Article(
+        feed_name="toutiao",
+        title="Test Title",
+        url="http://example.com",
+        text="Test Description",
+        soup=None,
+        published_at=datetime.now(timezone.utc),
+    )
+
+    prompt = explorer._get_summary_prompt(article)
+
+    assert "今日头条（Toutiao）ホットニュース" in prompt
+    assert "Test Title" in prompt
+    assert "Test Description" in prompt
+    assert "ニュースの概要" in prompt
+    assert "3. 社会的影響" in prompt
+    assert "4. 国際的視点" in prompt
+
+
+@pytest.mark.asyncio
+async def test_get_system_instruction(explorer):
+    """システム指示取得のテスト."""
+    instruction = explorer._get_system_instruction()
+
+    assert "今日头条" in instruction
+    assert "Toutiao" in instruction
+    assert "日本のユーザーに向けて" in instruction
+    assert "社会的影響" in instruction
+
+
+@pytest.mark.asyncio
+async def test_collect_success(explorer, mock_trendradar_client):
+    """収集処理の成功ケース."""
+    # Mock data
+    mock_trendradar_client.get_latest_news.return_value = [
+        {
+            "title": "Article 1",
+            "url": "http://example.com/1",
+            "desc": "Desc 1",
+            "hot": "100",
+            "time": "2024-03-20 10:00:00",
+        }
+    ]
+
+    # Mocking _summarize_article to avoid GPT calls and complexity
+    with patch.object(
+        explorer, "_summarize_article", new_callable=AsyncMock
+    ) as mock_summarize:
+        with patch.object(
+            explorer, "_store_articles", new_callable=AsyncMock
+        ) as mock_store:
+            mock_store.return_value = [("path/to.json", "path/to.md")]
+
+            result = await explorer.collect(days=1, limit=5)
+
+            assert len(result) == 1
+            mock_trendradar_client.get_latest_news.assert_called_once_with(
+                platform="toutiao", limit=5
+            )
+            mock_summarize.assert_called_once()
+            mock_store.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_transform_to_article_valid(explorer):
+    """_transform_to_article: 正常な変換のテスト."""
+    item = {
+        "title": "Valid Title",
+        "url": "http://example.com/valid",
+        "desc": "Valid Description",
+        "hot": "150",
+        "time": "2024-03-20 10:30:00",
+    }
+
+    article = explorer._transform_to_article(item)
+
+    assert article.title == "Valid Title"
+    assert article.url == "http://example.com/valid"
+    assert article.text == "Valid Description"
+    assert article.published_at.year == 2024
+    assert article.published_at.month == 3
+    assert article.published_at.day == 20
+    assert article.popularity_score == 150
+
+
+@pytest.mark.asyncio
+async def test_transform_to_article_null_fields(explorer):
+    """_transform_to_article: 必須フィールド欠落やnullのハンドリング."""
+    # desc is None
+    item = {
+        "title": "Title",
+        "url": "http://example.com",
+        "desc": None,
+        "hot": None,
+        "time": "2024-03-20 10:00:00",
+    }
+
+    article = explorer._transform_to_article(item)
+
+    assert article.text == ""  # Empty description handled
+    assert article.popularity_score == 0
+
+
+@pytest.mark.asyncio
+async def test_transform_to_article_time_parsing(explorer):
+    """_transform_to_article: timeフィールドのパーステスト."""
+
+    # specific format YYYY-MM-DD HH:MM
+    item_fmt = {
+        "title": "T",
+        "url": "U",
+        "desc": "D",
+        "hot": "0",
+        "time": "2024-12-31 23:59:00",
+    }
+    article_fmt = explorer._transform_to_article(item_fmt)
+    assert article_fmt.published_at.year == 2024
+    assert article_fmt.published_at.month == 12
+    assert article_fmt.published_at.day == 31
+
+    # timestamp (int/str)
+    ts = 1704067200  # 2024-01-01 00:00:00 UTC
+    item_ts = {"title": "T", "url": "U", "desc": "D", "hot": "0", "time": str(ts)}
+    article_ts = explorer._transform_to_article(item_ts)
+    assert article_ts.published_at.year == 2024
+
+    # timestamp (ms epoch)
+    ts_ms = 1704067200000  # 2024-01-01 00:00:00 UTC in milliseconds
+    item_ts_ms = {
+        "title": "T",
+        "url": "U",
+        "desc": "D",
+        "hot": "0",
+        "time": str(ts_ms),
+    }
+    article_ts_ms = explorer._transform_to_article(item_ts_ms)
+    assert article_ts_ms.published_at.year == 2024
+
+    # invalid time -> fallback to current time (mock datetime.now if strict, but here just check it defaults)
+    item_bad = {
+        "title": "T",
+        "url": "U",
+        "desc": "D",
+        "hot": "0",
+        "time": "invalid-time",
+    }
+    article_bad = explorer._transform_to_article(item_bad)
+    assert isinstance(article_bad.published_at, datetime)
+
+    # huge epoch should not crash and should fallback
+    item_huge = {
+        "title": "T",
+        "url": "U",
+        "desc": "D",
+        "hot": "0",
+        "time": "9999999999999999",
+    }
+    article_huge = explorer._transform_to_article(item_huge)
+    assert isinstance(article_huge.published_at, datetime)
+
+
+@pytest.mark.asyncio
+async def test_collect_client_error(explorer, mock_trendradar_client):
+    """collect: クライアントエラー時のハンドリング."""
+    mock_trendradar_client.get_latest_news.side_effect = ValueError("API Error")
+
+    # If exception handles internally -> Assert empty list or behavior
+    # If exception raises -> Use pytest.raises
+    with pytest.raises(ValueError):
+        await explorer.collect(days=1, limit=5)

--- a/tests/services/runner/test_run_services.py
+++ b/tests/services/runner/test_run_services.py
@@ -194,6 +194,13 @@ async def test_run_sync_service_dispatch_logic(monkeypatch):
     )
     service_mock.collect.assert_awaited_with(days=1, target_dates=single_date)
 
+    # --- Case 5e: trendradar-toutiao (single date) ---
+    # Expected: Works normally with single date
+    await runner._run_sync_service(
+        "trendradar-toutiao", service_mock, days=1, target_dates=single_date
+    )
+    service_mock.collect.assert_awaited_with(days=1, target_dates=single_date)
+
     # Check that INFO log shows single day ("対象日")
     info_calls = [str(c) for c in mock_logger.info.call_args_list]
     assert any("対象日" in c and "2024-01-01" in c for c in info_calls)


### PR DESCRIPTION
## 概要
今日頭条 (Toutiao) プラットフォームの TrendRadar 統合を実装しました。

## 変更内容
### Backend
- `ToutiaoExplorer` の実装とユニットテストの追加
- `TrendRadarPlatform` への `TOUTIAO` の追加
- `TrendRadarExplorerFactory` への登録

### Frontend
- Toutiao プラットフォームの表示設定（アイコン、色、名称）の追加
- サイドバーおよびメイン画面での表示対応

## 検証結果
- Backend: `uv run poe quality-check` (Ruff & Pytest) が全てパス
- Frontend: `npm run quality-check` (ESLint & Prettier) が全てパス


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toutiao (今日头条) added as a selectable content source with localized title, subtitle, date format, UI styling, and Japanese-language AI summaries.

* **Tests**
  * New tests for Toutiao covering initialization, prompts/system instruction content, collection, transformation, and error paths.

* **Documentation**
  * Integration guide updated with steps to register and enable Toutiao support.

* **Chores**
  * Runner/orchestration updated to include Toutiao in supported TrendRadar services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->