### PR TITLE
fix(ci): add actions:write permission for telemetry and caching

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -20,6 +20,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  actions: write
 
 jobs:
   quality-check:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,6 +24,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  actions: write
 
 jobs:
   quality-check:


### PR DESCRIPTION
## Overview
Fixes the 403 (Forbidden) errors occurring in the `Workflow Telemetry` action and the caching steps (`setup-uv`, `actions/setup-node`).

## Root Cause
The `permissions` block in the workflow files was too restrictive and did not include `actions: write`, which is required for:
1.  The telemetry action to publish its results.
2.  The caching mechanism to save cache data.

## Changes
- Updated `python-tests.yml` to include `actions: write` in `permissions`.
- Updated `js-tests.yml` to include `actions: write` in `permissions`.

## Bug Fix
- [x] Fixes `AxiosError: Request failed with status code 403` in telemetry steps.
- [x] Fixes `Failed to save cache: Cache service responded with 400` (related to permissions).