### PR TITLE
feat(trendradar): add Freebuf platform integration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ const sources = [
   'trendradar-toutiao',
   'trendradar-sspai',
   'trendradar-producthunt',
+  'trendradar-freebuf',
 ];
 
 function App() {
@@ -93,7 +94,7 @@ function App() {
           showWeather={false}
           showSearchButton={false}
           onMenuClick={toggleMobileMenu}
-          onSearchClick={() => {}}
+          onSearchClick={() => { }}
           rightActions={<></>}
         />
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -63,6 +63,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         'trendradar-toutiao',
         'trendradar-sspai',
         'trendradar-producthunt',
+        'trendradar-freebuf',
       ],
       defaultExpanded: true,
     },
@@ -143,11 +144,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
                           setSelectedSource(source);
                           onMenuItemClick();
                         }}
-                        className={`w-full text-left px-4 py-2 rounded-lg font-medium transition-colors min-h-touch touch-manipulation flex items-center ${
-                          selectedSource === source
+                        className={`w-full text-left px-4 py-2 rounded-lg font-medium transition-colors min-h-touch touch-manipulation flex items-center ${selectedSource === source
                             ? 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400'
                             : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700/30'
-                        }`}
+                          }`}
                       >
                         {sourceInfo.title}
                       </button>

--- a/frontend/src/config/sourceDisplayInfo.ts
+++ b/frontend/src/config/sourceDisplayInfo.ts
@@ -160,6 +160,14 @@ export const sourceDisplayInfo: Record<string, SourceDisplayInfo> = {
     gradientTo: 'to-rose-50',
     borderColor: 'border-orange-200',
   },
+  'trendradar-freebuf': {
+    title: 'Freebuf',
+    subtitle: '中国最大のセキュリティメディア',
+    dateFormat: 'yyyy年MM月dd日',
+    gradientFrom: 'from-slate-50',
+    gradientTo: 'to-gray-50',
+    borderColor: 'border-slate-300',
+  },
 };
 
 // デフォルト設定

--- a/nook/api/routers/content.py
+++ b/nook/api/routers/content.py
@@ -61,6 +61,7 @@ SOURCE_MAPPING = {
     "trendradar-toutiao": "trendradar-toutiao",
     "trendradar-sspai": "trendradar-sspai",
     "trendradar-producthunt": "trendradar-producthunt",
+    "trendradar-freebuf": "trendradar-freebuf",
 }
 
 
@@ -213,6 +214,7 @@ async def get_content(
             "trendradar-toutiao",
             "trendradar-sspai",
             "trendradar-producthunt",
+            "trendradar-freebuf",
         ):
             articles_data = storage.load_json(service_name, target_date)
             if articles_data:
@@ -280,6 +282,7 @@ async def get_content(
                 "trendradar-toutiao",
                 "trendradar-sspai",
                 "trendradar-producthunt",
+                "trendradar-freebuf",
             ):
                 # TrendRadar系はJSONから個別記事として追加
                 articles_data = storage.load_json(service_name, target_date)
@@ -367,5 +370,6 @@ def _get_source_display_name(source: str) -> str:
         "trendradar-toutiao": "今日头条 (Toutiao)",
         "trendradar-sspai": "少数派 (SSPai)",
         "trendradar-producthunt": "Product Hunt",
+        "trendradar-freebuf": "Freebuf",
     }
     return source_names.get(source, source)

--- a/nook/services/explorers/trendradar/__init__.py
+++ b/nook/services/explorers/trendradar/__init__.py
@@ -1,6 +1,7 @@
 """TrendRadar integration module."""
 
 from nook.services.explorers.trendradar.base import BaseTrendRadarExplorer
+from nook.services.explorers.trendradar.freebuf_explorer import FreebufExplorer
 from nook.services.explorers.trendradar.ithome_explorer import IthomeExplorer
 from nook.services.explorers.trendradar.juejin_explorer import JuejinExplorer
 from nook.services.explorers.trendradar.kr36_explorer import Kr36Explorer
@@ -24,4 +25,5 @@ __all__ = [
     "WeiboExplorer",
     "ToutiaoExplorer",
     "SspaiExplorer",
+    "FreebufExplorer",
 ]

--- a/nook/services/explorers/trendradar/freebuf_explorer.py
+++ b/nook/services/explorers/trendradar/freebuf_explorer.py
@@ -1,0 +1,76 @@
+"""FreebufExplorer - TrendRadar経由でFreebufのホットトピックを取得.
+
+このモジュールは、TrendRadar MCPサーバーを経由して
+Freebuf（中国最大のセキュリティメディア）のホットトピックを取得する
+FreebufExplorerクラスを提供します。
+"""
+
+from nook.core.config import BaseConfig
+from nook.services.base.base_feed_service import Article
+from nook.services.explorers.trendradar.base import BaseTrendRadarExplorer
+
+
+class FreebufExplorer(BaseTrendRadarExplorer):
+    """FreebufのホットトピックをTrendRadar経由で取得するExplorer.
+
+    TrendRadar MCPサーバーと通信し、
+    Freebuf（中国最大のセキュリティメディア）のホットトピックを取得・要約・保存します。
+
+    Parameters
+    ----------
+    storage_dir : str, default="var/data"
+        データ保存ディレクトリのルートパス。
+    config : BaseConfig | None, default=None
+        設定オブジェクト。
+
+    Examples
+    --------
+    >>> explorer = FreebufExplorer()
+    >>> explorer.run(days=1, limit=20)
+    """
+
+    # プラットフォーム固有の設定
+    PLATFORM_NAME = "freebuf"
+    FEED_NAME = "freebuf"
+    MARKDOWN_HEADER = "Freebufホットトピック"
+
+    def __init__(self, storage_dir: str = "var/data", config: BaseConfig | None = None):
+        """FreebufExplorerを初期化.
+
+        Parameters
+        ----------
+        storage_dir : str, default="var/data"
+            データ保存ディレクトリのルートパス。
+        config : BaseConfig | None, default=None
+            設定オブジェクト。
+        """
+        super().__init__(
+            service_name="trendradar-freebuf",
+            storage_dir=storage_dir,
+            config=config,
+        )
+
+    def _get_summary_prompt(self, article: Article) -> str:
+        """GPT要約用のプロンプトを生成."""
+        return self._get_default_summary_prompt(
+            article=article,
+            platform_label="Freebuf",
+            content_label="ホットトピック",
+            sections=[
+                "セキュリティトピックの概要 (1-2文)\n[脅威・脆弱性・セキュリティ技術の概要を簡潔に説明]",
+                "技術的詳細 (箇条書き3-5点)\n- [ポイント1: 攻撃手法/脆弱性の種類]\n"
+                "- [ポイント2: 影響を受けるシステム・ソフトウェア]\n"
+                "- [ポイント3: 検知・防御方法]",
+                "業界への影響\n[セキュリティ業界や企業への影響]",
+                "日本での対策・関連事例\n[日本で参考になる対策や類似事例]",
+            ],
+        )
+
+    def _get_system_instruction(self) -> str:
+        """GPT要約用のシステム指示を取得."""
+        return (
+            "あなたは中国のサイバーセキュリティメディア「Freebuf」のトレンドを"
+            "日本語で解説する専門のアシスタントです。日本のセキュリティエンジニアに向けて、"
+            "脅威の技術的詳細、攻撃手法、防御策、影響範囲が"
+            "伝わるような具体的で情報量の多い要約を作成してください。"
+        )

--- a/nook/services/explorers/trendradar/trendradar_client.py
+++ b/nook/services/explorers/trendradar/trendradar_client.py
@@ -54,6 +54,7 @@ class TrendRadarClient:
         "toutiao",
         "sspai",
         "producthunt",
+        "freebuf",
     ]
 
     def __init__(self, base_url: str | None = None):

--- a/nook/services/runner/runner_impl.py
+++ b/nook/services/runner/runner_impl.py
@@ -41,6 +41,7 @@ TRENDRADAR_SERVICES = {
     "trendradar-toutiao",
     "trendradar-sspai",
     "trendradar-producthunt",
+    "trendradar-freebuf",
 }
 
 
@@ -58,6 +59,7 @@ class ServiceRunner:
         from nook.services.explorers.note.note_explorer import NoteExplorer
         from nook.services.explorers.qiita.qiita_explorer import QiitaExplorer
         from nook.services.explorers.reddit.reddit_explorer import RedditExplorer
+        from nook.services.explorers.trendradar.freebuf_explorer import FreebufExplorer
         from nook.services.explorers.trendradar.ithome_explorer import IthomeExplorer
         from nook.services.explorers.trendradar.juejin_explorer import JuejinExplorer
         from nook.services.explorers.trendradar.kr36_explorer import Kr36Explorer
@@ -98,6 +100,7 @@ class ServiceRunner:
             "trendradar-toutiao": ToutiaoExplorer,
             "trendradar-sspai": SspaiExplorer,
             "trendradar-producthunt": ProductHuntExplorer,
+            "trendradar-freebuf": FreebufExplorer,
         }
         for service_name in TRENDRADAR_SERVICES:
             if service_name in trendradar_mapping:

--- a/tests/services/explorers/trendradar/test_freebuf_explorer.py
+++ b/tests/services/explorers/trendradar/test_freebuf_explorer.py
@@ -1,0 +1,210 @@
+"""FreebufExplorerのテストモジュール."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nook.services.base.base_feed_service import Article
+from nook.services.explorers.trendradar.base import create_empty_soup
+from nook.services.explorers.trendradar.freebuf_explorer import FreebufExplorer
+from nook.services.explorers.trendradar.trendradar_client import TrendRadarClient
+
+
+@pytest.fixture
+def mock_trendradar_client():
+    with patch(
+        "nook.services.explorers.trendradar.base.TrendRadarClient"
+    ) as MockClient:
+        client_instance = AsyncMock()
+        MockClient.return_value = client_instance
+        yield client_instance
+
+
+@pytest.fixture
+def explorer(mock_trendradar_client):
+    return FreebufExplorer(storage_dir="test_data")
+
+
+@pytest.mark.asyncio
+async def test_initialization(explorer):
+    """初期化のテスト."""
+    assert explorer.service_name == "trendradar-freebuf"
+    assert explorer.PLATFORM_NAME == "freebuf"
+    assert explorer.FEED_NAME == "freebuf"
+    assert explorer.MARKDOWN_HEADER == "Freebufホットトピック"
+
+
+@pytest.mark.asyncio
+async def test_get_summary_prompt(explorer):
+    """プロンプト生成のテスト."""
+    article = Article(
+        feed_name="freebuf",
+        title="Test Security Title",
+        url="http://example.com",
+        text="Test Security Description",
+        soup=create_empty_soup(),
+        published_at=datetime.now(timezone.utc),
+    )
+
+    prompt = explorer._get_summary_prompt(article)
+
+    assert "Freebufホットトピック" in prompt
+    assert "Test Security Title" in prompt
+    assert "Test Security Description" in prompt
+    assert "セキュリティトピックの概要" in prompt
+    assert "技術的詳細" in prompt
+    assert "業界への影響" in prompt
+    assert "日本での対策・関連事例" in prompt
+
+
+@pytest.mark.asyncio
+async def test_get_system_instruction(explorer):
+    """システム指示取得のテスト."""
+    instruction = explorer._get_system_instruction()
+
+    assert "Freebuf" in instruction
+    assert "セキュリティ" in instruction
+    assert "日本のセキュリティエンジニア" in instruction
+    assert "攻撃手法" in instruction
+
+
+def test_freebuf_is_supported_platform_in_client():
+    """FreebufがTrendRadarClientでサポートされているか確認."""
+    assert "freebuf" in TrendRadarClient.SUPPORTED_PLATFORMS
+
+
+@pytest.mark.asyncio
+async def test_collect_success(explorer, mock_trendradar_client):
+    """収集処理の成功ケース."""
+    mock_trendradar_client.get_latest_news.return_value = [
+        {
+            "title": "Security Article 1",
+            "url": "http://example.com/1",
+            "desc": "Security Desc 1",
+            "hot": "100",
+            "time": "2024-03-20 10:00:00",
+        }
+    ]
+
+    with patch.object(
+        explorer, "_summarize_article", new_callable=AsyncMock
+    ) as mock_summarize:
+        with patch.object(
+            explorer, "_store_articles", new_callable=AsyncMock
+        ) as mock_store:
+            mock_store.return_value = [("path/to.json", "path/to.md")]
+
+            result = await explorer.collect(days=1, limit=5)
+
+            assert len(result) == 1
+            mock_trendradar_client.get_latest_news.assert_called_once_with(
+                platform="freebuf", limit=5
+            )
+            mock_summarize.assert_called_once()
+            mock_store.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_transform_to_article_valid(explorer):
+    """_transform_to_article: 正常な変換のテスト."""
+    item = {
+        "title": "Valid Security Title",
+        "url": "http://example.com/valid",
+        "desc": "Valid Security Description",
+        "hot": "150",
+        "time": "2024-03-20 10:30:00",
+    }
+
+    article = explorer._transform_to_article(item)
+
+    assert article.title == "Valid Security Title"
+    assert article.url == "http://example.com/valid"
+    assert article.text == "Valid Security Description"
+    assert article.published_at.year == 2024
+    assert article.published_at.month == 3
+    assert article.published_at.day == 20
+    assert article.popularity_score == 150
+
+
+@pytest.mark.asyncio
+async def test_transform_to_article_null_fields(explorer):
+    """_transform_to_article: 必須フィールド欠落やnullのハンドリング."""
+    item = {
+        "title": "Title",
+        "url": "http://example.com",
+        "desc": None,
+        "hot": None,
+        "time": "2024-03-20 10:00:00",
+    }
+
+    article = explorer._transform_to_article(item)
+
+    assert article.text == ""
+    assert article.popularity_score == 0
+
+
+@pytest.mark.asyncio
+async def test_transform_to_article_time_parsing(explorer):
+    """_transform_to_article: timeフィールドのパーステスト."""
+    # specific format YYYY-MM-DD HH:MM
+    item_fmt = {
+        "title": "T",
+        "url": "U",
+        "desc": "D",
+        "hot": "0",
+        "time": "2024-12-31 23:59:00",
+    }
+    article_fmt = explorer._transform_to_article(item_fmt)
+    assert article_fmt.published_at.year == 2024
+    assert article_fmt.published_at.month == 12
+    assert article_fmt.published_at.day == 31
+
+    # timestamp (int/str)
+    ts = 1704067200  # 2024-01-01 00:00:00 UTC
+    item_ts = {"title": "T", "url": "U", "desc": "D", "hot": "0", "time": str(ts)}
+    article_ts = explorer._transform_to_article(item_ts)
+    assert article_ts.published_at.year == 2024
+
+    # timestamp (ms epoch)
+    ts_ms = 1704067200000  # 2024-01-01 00:00:00 UTC in milliseconds
+    item_ts_ms = {
+        "title": "T",
+        "url": "U",
+        "desc": "D",
+        "hot": "0",
+        "time": str(ts_ms),
+    }
+    article_ts_ms = explorer._transform_to_article(item_ts_ms)
+    assert article_ts_ms.published_at.year == 2024
+
+    # invalid time -> fallback to current time
+    item_bad = {
+        "title": "T",
+        "url": "U",
+        "desc": "D",
+        "hot": "0",
+        "time": "invalid-time",
+    }
+    article_bad = explorer._transform_to_article(item_bad)
+    assert isinstance(article_bad.published_at, datetime)
+
+    # huge epoch should not crash and should fallback
+    item_huge = {
+        "title": "T",
+        "url": "U",
+        "desc": "D",
+        "hot": "0",
+        "time": "9999999999999999",
+    }
+    article_huge = explorer._transform_to_article(item_huge)
+    assert isinstance(article_huge.published_at, datetime)
+
+
+@pytest.mark.asyncio
+async def test_collect_client_error(explorer, mock_trendradar_client):
+    """collect: クライアントエラー時のハンドリング."""
+    mock_trendradar_client.get_latest_news.side_effect = ValueError("API Error")
+
+    with pytest.raises(ValueError):
+        await explorer.collect(days=1, limit=5)


### PR DESCRIPTION
## 概要
TrendRadar MCPサーバー経由で**Freebuf**（中国最大のセキュリティメディア）のホットトピックを取得する機能を追加。

## 変更内容
### 新規ファイル
- `nook/services/explorers/trendradar/freebuf_explorer.py` - FreebufExplorerクラス
- `tests/services/explorers/trendradar/test_freebuf_explorer.py` - テスト（9件）

### 変更ファイル
- `nook/services/runner/runner_impl.py` - サービス登録
- `nook/api/routers/content.py` - SOURCE_MAPPING追加
- `nook/services/explorers/trendradar/__init__.py` - エクスポート追加
- `nook/services/explorers/trendradar/trendradar_client.py` - SUPPORTED_PLATFORMS追加
- `frontend/src/config/sourceDisplayInfo.ts` - 表示設定追加
- `frontend/src/components/layout/Sidebar.tsx` - グループ追加
- `frontend/src/App.tsx` - sources配列追加

## テスト結果
- pytest: 全193件 PASS
- ruff: All checks passed
- frontend lint: PASS

## 関連
3プラットフォーム追加計画の Phase 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Freebuf as a new content source for security trends. Freebuf, China's leading security media platform, provides hot topic coverage with enhanced Japanese context and translations for security professionals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->